### PR TITLE
Adds BlockExplodeEvent listener, adding support for bed/respawn anchors explosions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
+            <version>1.19.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Also prevents players being harmed by Block Explode events.

Also considers Ender Crystal explosions as true for `isTNT()` tests.

Closes #15.